### PR TITLE
fix 修复查询订单，apiUrl 在请求拦截器中未正确生成签名

### DIFF
--- a/src/apis/basePay/basePay.ts
+++ b/src/apis/basePay/basePay.ts
@@ -82,11 +82,11 @@ export class BasePay {
   protected async _transactionIdQueryOrder<T = any>(data: any) {
     const { transaction_id, ...query } = data
     const isBusiness = data.mchid !== undefined
-    const _ = isBusiness ? UrlMap.transactionIdQueryOrder.business : UrlMap.transactionIdQueryOrder.provider
+    const _ = isBusiness ? UrlMap.transactionIdQueryOrder.business + '?mchid=' + query.mchid : UrlMap.transactionIdQueryOrder.provider + '?sp_mchid=' + query.sp_mchid + '&sub_mchid=' + query.sub_mchid
     const apiUrl = replaceTagText(_, {
       transaction_id,
     })
-    const result = await this.base.request.get<T>(apiUrl, { params: query })
+    const result = await this.base.request.get<T>(apiUrl)
     return result.data
   }
   /**
@@ -106,11 +106,11 @@ export class BasePay {
   async _outTradeNoQueryOrder<T = any>(data: any) {
     const { out_trade_no, ...query } = data
     const isBusiness = data.mchid !== undefined
-    const _ = isBusiness ? UrlMap.outTradeNoQueryOrder.business : UrlMap.outTradeNoQueryOrder.provider
+    const _ = isBusiness ? UrlMap.outTradeNoQueryOrder.business + '?mchid=' + query.mchid : UrlMap.outTradeNoQueryOrder.provider + '?sp_mchid=' + query.sp_mchid + '&sub_mchid=' + query.sub_mchid
     const apiUrl = replaceTagText(_, {
       out_trade_no,
     })
-    const result = await this.base.request.get<T>(apiUrl, { params: query })
+    const result = await this.base.request.get<T>(apiUrl)
     return result.data
   }
   /**


### PR DESCRIPTION
查询微信支付订单，报签名不正确。原因是 apiUrl 未把 mchid（直连商户，服务商是 sp_mchid 和 sub_mchid） 加到 url 地址中，导致后面在请求拦截器中生成的签名缺少了这些参数，与官方验签不一致。